### PR TITLE
feat: Add OIDC standard claims to User interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ login() => Promise<User>
 ```
 
 Web Auth: Login with Auth0.
+Default scope is `openid profile email offline_access`.
 
 **Returns:** <code>Promise&lt;<a href="#user">User</a>&gt;</code>
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Capacitor Auth0 Plugin
 ### load()
 
 ```typescript
-load() => Promise<Auth0User>
+load() => Promise<User>
 ```
 
 Load auth0 plugin.
@@ -103,7 +103,7 @@ using the refresh token if the access token is expired.
 For android, initialize the plugin with your Auth0 configuration.
 Return undefined if the user is not authenticated.
 
-**Returns:** <code>Promise&lt;<a href="#auth0user">Auth0User</a>&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#user">User</a>&gt;</code>
 
 --------------------
 
@@ -111,12 +111,12 @@ Return undefined if the user is not authenticated.
 ### login()
 
 ```typescript
-login() => Promise<Auth0User>
+login() => Promise<User>
 ```
 
 Web Auth: Login with Auth0.
 
-**Returns:** <code>Promise&lt;<a href="#auth0user">Auth0User</a>&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#user">User</a>&gt;</code>
 
 --------------------
 
@@ -148,14 +148,14 @@ Check if the user is authenticated.
 ### getUserInfo()
 
 ```typescript
-getUserInfo() => Promise<Auth0User>
+getUserInfo() => Promise<User>
 ```
 
 Get the authenticated user profile.
 If the access token is expired, yield new credentials using the refresh token.
 Throws an error if the user is not authenticated.
 
-**Returns:** <code>Promise&lt;<a href="#auth0user">Auth0User</a>&gt;</code>
+**Returns:** <code>Promise&lt;<a href="#user">User</a>&gt;</code>
 
 --------------------
 
@@ -177,15 +177,15 @@ Return undefined if the user is not authenticated.
 ### Interfaces
 
 
-#### Auth0User
+#### User
 
 Auth0 user profile.
 
-| Prop        | Type                | Description |
-| ----------- | ------------------- | ----------- |
-| **`id`**    | <code>string</code> | User ID.    |
-| **`name`**  | <code>string</code> | User name.  |
-| **`email`** | <code>string</code> | User email. |
+| Prop        | Type                | Description                     |
+| ----------- | ------------------- | ------------------------------- |
+| **`id`**    | <code>string</code> | <a href="#user">User</a> ID.    |
+| **`name`**  | <code>string</code> | <a href="#user">User</a> name.  |
+| **`email`** | <code>string</code> | <a href="#user">User</a> email. |
 
 
 #### Credentials

--- a/README.md
+++ b/README.md
@@ -181,11 +181,29 @@ Return undefined if the user is not authenticated.
 
 Auth0 user profile.
 
-| Prop        | Type                | Description                     |
-| ----------- | ------------------- | ------------------------------- |
-| **`id`**    | <code>string</code> | <a href="#user">User</a> ID.    |
-| **`name`**  | <code>string</code> | <a href="#user">User</a> name.  |
-| **`email`** | <code>string</code> | <a href="#user">User</a> email. |
+| Prop                      | Type                          | Description                                                     |
+| ------------------------- | ----------------------------- | --------------------------------------------------------------- |
+| **`id`**                  | <code>string</code>           | The user identifier.                                            |
+| **`name`**                | <code>string</code>           | The name of the user. Require `profile` scope.                  |
+| **`givenName`**           | <code>string</code>           | The given name of the user. Require `profile` scope.            |
+| **`familyName`**          | <code>string</code>           | The family name of the user. Require `profile` scope.           |
+| **`middleName`**          | <code>string</code>           | The middle name of the user. Require `profile` scope.           |
+| **`nickname`**            | <code>string</code>           | The nickname of the user. Require `profile` scope.              |
+| **`preferredUsername`**   | <code>string</code>           | The preferred username of the user. Require `profile` scope.    |
+| **`profile`**             | <code>string</code>           | The URL of the user's profile page. Require `profile` scope.    |
+| **`picture`**             | <code>string</code>           | The URL of the user's profile picture. Require `profile` scope. |
+| **`website`**             | <code>string</code>           | The URL of the user's website. Require `profile` scope.         |
+| **`gender`**              | <code>string</code>           | The gender of the user. Require `profile` scope.                |
+| **`birthdate`**           | <code>string</code>           | The birthdate of the user. Require `profile` scope.             |
+| **`zoneinfo`**            | <code>string</code>           | The zoneinfo of the user. Require `profile` scope.              |
+| **`locale`**              | <code>string</code>           | The locale of the user. Require `profile` scope.                |
+| **`updatedAt`**           | <code>string</code>           | Datetime of last updated. Requre `profile` scope.               |
+| **`email`**               | <code>string</code>           | The email address of the user. Require `email` scope.           |
+| **`emailVerified`**       | <code>boolean</code>          | If the user's email is verified. Require `email` scope.         |
+| **`address`**             | <code>[string: string]</code> | The address of the user. Require `address` scope.               |
+| **`phoneNumber`**         | <code>string</code>           | The phone number of the user. Require `phone` scope.            |
+| **`phoneNumberVerified`** | <code>boolean</code>          | If the user's phone number is verified. Require `phone` scope.  |
+| **`customClaims`**        | <code>[string: any]</code>    | Other claims from the identity token.                           |
 
 
 #### Credentials

--- a/example/src/js/capacitor-auth0.js
+++ b/example/src/js/capacitor-auth0.js
@@ -146,6 +146,7 @@ window.customElements.define(
       });
 
       Auth0.load().then(user => {
+        console.log('load', user);
         updateUI(user);
         return showCredentials();
       });

--- a/ios/Plugin/Auth0Plugin.swift
+++ b/ios/Plugin/Auth0Plugin.swift
@@ -19,7 +19,25 @@ public class Auth0Plugin: CAPPlugin {
                 call.resolve([
                     "id": user?.id as Any,
                     "name": user?.name as Any,
-                    "email": user?.email as Any
+                    "givenName": user?.givenName as Any,
+                    "familyName": user?.familyName as Any,
+                    "middleName": user?.middleName as Any,
+                    "nickname": user?.nickname as Any,
+                    "preferredUsername": user?.preferredUsername as Any,
+                    "profile": user?.profile as Any,
+                    "picture": user?.picture as Any,
+                    "website": user?.website as Any,
+                    "gender": user?.gender as Any,
+                    "birthdate": user?.birthdate as Any,
+                    "zoneinfo": user?.zoneinfo as Any,
+                    "locale": user?.locale as Any,
+                    "updatedAt": user?.updatedAt as Any,
+                    "email": user?.email as Any,
+                    "emailVerified": user?.emailVerified as Any,
+                    "address": user?.address as Any,
+                    "phoneNumber": user?.phoneNumber as Any,
+                    "phoneNumberVerified": user?.phoneNumberVerified as Any,
+                    "customClaims": user?.customClaims as Any
                 ])
             case .failure(_):
                 call.resolve()
@@ -40,7 +58,25 @@ public class Auth0Plugin: CAPPlugin {
                     call.resolve([
                         "id": user?.id as Any,
                         "name": user?.name as Any,
-                        "email": user?.email as Any
+                        "givenName": user?.givenName as Any,
+                        "familyName": user?.familyName as Any,
+                        "middleName": user?.middleName as Any,
+                        "nickname": user?.nickname as Any,
+                        "preferredUsername": user?.preferredUsername as Any,
+                        "profile": user?.profile as Any,
+                        "picture": user?.picture as Any,
+                        "website": user?.website as Any,
+                        "gender": user?.gender as Any,
+                        "birthdate": user?.birthdate as Any,
+                        "zoneinfo": user?.zoneinfo as Any,
+                        "locale": user?.locale as Any,
+                        "updatedAt": user?.updatedAt as Any,
+                        "email": user?.email as Any,
+                        "emailVerified": user?.emailVerified as Any,
+                        "address": user?.address as Any,
+                        "phoneNumber": user?.phoneNumber as Any,
+                        "phoneNumberVerified": user?.phoneNumberVerified as Any,
+                        "customClaims": user?.customClaims as Any
                     ])
                 case .failure(let error):
                     call.reject("Failed with: \(error)")
@@ -86,7 +122,25 @@ public class Auth0Plugin: CAPPlugin {
                 call.resolve([
                     "id": user?.id as Any,
                     "name": user?.name as Any,
-                    "email": user?.email as Any
+                    "givenName": user?.givenName as Any,
+                    "familyName": user?.familyName as Any,
+                    "middleName": user?.middleName as Any,
+                    "nickname": user?.nickname as Any,
+                    "preferredUsername": user?.preferredUsername as Any,
+                    "profile": user?.profile as Any,
+                    "picture": user?.picture as Any,
+                    "website": user?.website as Any,
+                    "gender": user?.gender as Any,
+                    "birthdate": user?.birthdate as Any,
+                    "zoneinfo": user?.zoneinfo as Any,
+                    "locale": user?.locale as Any,
+                    "updatedAt": user?.updatedAt as Any,
+                    "email": user?.email as Any,
+                    "emailVerified": user?.emailVerified as Any,
+                    "address": user?.address as Any,
+                    "phoneNumber": user?.phoneNumber as Any,
+                    "phoneNumberVerified": user?.phoneNumberVerified as Any,
+                    "customClaims": user?.customClaims as Any
                 ])
             case .failure(let error):
                 call.reject("Renewing credentials is failed with: \(error)")

--- a/ios/Plugin/User.swift
+++ b/ios/Plugin/User.swift
@@ -10,20 +10,206 @@ import Foundation
 import JWTDecode
 
 struct User {
+
+    public static let publicClaims = [
+        "sub",
+        "name",
+        "given_name",
+        "family_name",
+        "middle_name",
+        "nickname",
+        "preferred_username",
+        "profile",
+        "picture",
+        "website",
+        "email",
+        "email_verified",
+        "gender",
+        "birthdate",
+        "zoneinfo",
+        "locale",
+        "phone_number",
+        "phone_number_verified",
+        "address",
+        "updated_at"
+    ]
+
+    /**
+     * The user identifier.
+     */
     let id: String
-    let name: String
+
+    /**
+     * The name of the user.
+     * Require `profile` scope.
+     */
+    let name: String?
+
+    /**
+     * The given name of the user.
+     * Require `profile` scope.
+     */
+    let givenName: String?
+
+    /**
+     * The family name of the user.
+     * Require `profile` scope.
+     */
+    let familyName: String?
+
+    /**
+     * The middle name of the user.
+     * Require `profile` scope.
+     */
+    let middleName: String?
+
+    /**
+     * The nickname of the user.
+     * Require `profile` scope.
+     */
+    let nickname: String?
+
+    /**
+     * The preferred username of the user.
+     * Require `profile` scope.
+     */
+    let preferredUsername: String?
+
+    /**
+     * The URL of the user's profile page.
+     * Require `profile` scope.
+     */
+    let profile: String?
+
+    /**
+     * The URL of the user's profile picture.
+     * Require `profile` scope.
+     */
+    let picture: String?
+
+    /**
+     * The URL of the user's website.
+     * Require `profile` scope.
+     */
+    let website: String?
+
+    /**
+     * The gender of the user.
+     * Require `profile` scope.
+     */
+    let gender: String?
+
+    /**
+     * The birthdate of the user.
+     * Require `profile` scope.
+     */
+    let birthdate: String?
+
+    /**
+     * The zoneinfo of the user.
+     * Require `profile` scope.
+     */
+    let zoneinfo: String?
+
+    /**
+     * The locale of the user.
+     * Require `profile` scope.
+     */
+    let locale: String?
+
+    /**
+     * Datetime of last updated.
+     * Requre `profile` scope.
+     */
+    let updatedAt: String?
+
+    /**
+     * The email address of the user.
+     * Require `email` scope.
+     */
     let email: String?
+
+    /**
+     * If the user's email is verified.
+     * Require `email` scope.
+     */
+    let emailVerified: Bool?
+
+    /**
+     * The address of the user.
+     * Require `address` scope.
+     */
+    let address: [String: String]?
+
+    /**
+     * The phone number of the user.
+     * Require `phone` scope.
+     */
+    let phoneNumber: String?
+
+    /**
+     * If the user's phone number is verified.
+     * Require `phone` scope.
+     */
+    let phoneNumberVerified: Bool?
+
+    /**
+     * Other claims from the identity token.
+     */
+    let customClaims: [String: Any]?
+
 }
 
 extension User {
     init?(from idToken: String) {
         guard let jwt = try? decode(jwt: idToken),
-              let id = jwt.subject,
-              let name = jwt["name"].string else {
+              let id = jwt.subject else {
             return nil
         }
-        self.id = id
-        self.name = name
-        self.email = jwt["email"].string
+        
+        let name = jwt["name"].string
+        let givenName = jwt["given_name"].string
+        let familyName = jwt["family_name"].string
+        let middleName = jwt["middle_name"].string
+        let nickname = jwt["nickname"].string
+        let preferredUsername = jwt["preferred_username"].string
+        let profile = jwt["profile"].string
+        let picture = jwt["picture"].string
+        let website = jwt["website"].string
+        let gender = jwt["gender"].string
+        let birthdate = jwt["birthdate"].string
+        let zoneinfo = jwt["zoneinfo"].string
+        let locale = jwt["locale"].string
+        let updatedAt = jwt["updated_at"].string
+        let email = jwt["email"].string
+        let emailVerified = jwt["email_verified"].boolean
+        let address = jwt["address"].rawValue as? [String: String]
+        let phoneNumber = jwt["phone_number"].string
+        let phoneNumberVerified = jwt["phone_number_verified"].boolean
+        
+        var customClaims = jwt.body
+        User.publicClaims.forEach { customClaims.removeValue(forKey: $0) }
+        
+        self.init(id: id,
+                  name: name,
+                  givenName: givenName,
+                  familyName: familyName,
+                  middleName: middleName,
+                  nickname: nickname,
+                  preferredUsername: preferredUsername,
+                  profile: profile,
+                  picture: picture,
+                  website: website,
+                  gender: gender,
+                  birthdate: birthdate,
+                  zoneinfo: zoneinfo,
+                  locale: locale,
+                  updatedAt: updatedAt,
+                  email: email,
+                  emailVerified: emailVerified,
+                  address: address,
+                  phoneNumber: phoneNumber,
+                  phoneNumberVerified: phoneNumberVerified,
+                  customClaims: customClaims)
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -9,15 +9,15 @@ export interface Auth0Plugin {
    * using the refresh token if the access token is expired.
    * For android, initialize the plugin with your Auth0 configuration.
    * Return undefined if the user is not authenticated.
-   * @returns Promise<Auth0User>  Current authenticated user or undefined.
+   * @returns Promise<User>  Current authenticated user or undefined.
    */
-  load(): Promise<Auth0User>;
+  load(): Promise<User>;
 
   /**
    * Web Auth: Login with Auth0.
-   * @returns Promise<Auth0User>
+   * @returns Promise<User>
    */
-  login(): Promise<Auth0User>;
+  login(): Promise<User>;
 
   /**
    * Web Auth: Logout from Auth0.
@@ -35,9 +35,9 @@ export interface Auth0Plugin {
    * Get the authenticated user profile.
    * If the access token is expired, yield new credentials using the refresh token.
    * Throws an error if the user is not authenticated.
-   * @returns Promise<Auth0User>
+   * @returns Promise<User>
    */
-  getUserInfo(): Promise<Auth0User>;
+  getUserInfo(): Promise<User>;
 
   /**
    * Get credentials and yield new credentials using the refresh token if the access token is expired.
@@ -50,7 +50,7 @@ export interface Auth0Plugin {
 /**
  * Auth0 user profile.
  */
-export interface Auth0User {
+export interface User {
 
   /**
    * User ID.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -15,6 +15,7 @@ export interface Auth0Plugin {
 
   /**
    * Web Auth: Login with Auth0.
+   * Default scope is `openid profile email offline_access`.
    * @returns Promise<User>
    */
   login(): Promise<User>;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -53,19 +53,128 @@ export interface Auth0Plugin {
 export interface User {
 
   /**
-   * User ID.
+   * The user identifier.
    */
   id: string;
 
   /**
-   * User name.
+   * The name of the user.
+   * Require `profile` scope.
    */
   name: string;
 
   /**
-   * User email.
+   * The given name of the user.
+   * Require `profile` scope.
+   */
+  givenName: string;
+
+  /**
+   * The family name of the user.
+   * Require `profile` scope.
+   */
+  familyName: string;
+
+  /**
+   * The middle name of the user.
+   * Require `profile` scope.
+   */
+  middleName: string;
+
+  /**
+   * The nickname of the user.
+   * Require `profile` scope.
+   */
+  nickname: string;
+
+  /**
+   * The preferred username of the user.
+   * Require `profile` scope.
+   */
+  preferredUsername: string;
+
+  /**
+   * The URL of the user's profile page.
+   * Require `profile` scope.
+   */
+  profile: string;
+
+  /**
+   * The URL of the user's profile picture.
+   * Require `profile` scope.
+   */
+  picture: string;
+
+  /**
+   * The URL of the user's website.
+   * Require `profile` scope.
+   */
+  website: string;
+
+  /**
+   * The gender of the user.
+   * Require `profile` scope.
+   */
+  gender: string;
+
+  /**
+   * The birthdate of the user.
+   * Require `profile` scope.
+   */
+  birthdate: string;
+
+  /**
+   * The zoneinfo of the user.
+   * Require `profile` scope.
+   */
+  zoneinfo: string;
+
+  /**
+   * The locale of the user.
+   * Require `profile` scope.
+   */
+  locale: string;
+
+  /**
+   * Datetime of last updated.
+   * Requre `profile` scope.
+   */
+  updatedAt: string;
+
+  /**
+   * The email address of the user.
+   * Require `email` scope.
    */
   email: string;
+
+  /**
+   * If the user's email is verified.
+   * Require `email` scope.
+   */
+  emailVerified: boolean;
+
+  /**
+   * The address of the user.
+   * Require `address` scope.
+   */
+  address: [string: string];
+
+  /**
+   * The phone number of the user.
+   * Require `phone` scope.
+   */
+  phoneNumber: string;
+
+  /**
+   * If the user's phone number is verified.
+   * Require `phone` scope.
+   */
+  phoneNumberVerified: boolean;
+
+  /**
+   * Other claims from the identity token.
+   */
+  customClaims: [string: any];
 }
 
 /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,17 +1,17 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { Auth0Plugin, Auth0User, Credentials } from './definitions';
+import type { Auth0Plugin, User, Credentials } from './definitions';
 
 export class Auth0Web
   extends WebPlugin
   implements Auth0Plugin
 {
 
-  load(): Promise<Auth0User> {
+  load(): Promise<User> {
     return Promise.reject('Not implemented on web.');
   }
 
-  login(): Promise<Auth0User> {
+  login(): Promise<User> {
     return Promise.reject('Not implemented on web.');
   }
 
@@ -23,7 +23,7 @@ export class Auth0Web
     return Promise.reject('Not implemented on web.');
   }
 
-  getUserInfo(): Promise<Auth0User> {
+  getUserInfo(): Promise<User> {
     return Promise.reject('Not implemented on web.');
   }
 


### PR DESCRIPTION
Resolve #4

- Rename `Auth0User` to `User`.
- Add [standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) to `User` interface.